### PR TITLE
Fix duplicate FC8 infantry entry

### DIFF
--- a/server/troop_data/troop_definitions.py
+++ b/server/troop_data/troop_definitions.py
@@ -135,7 +135,7 @@ TROOP_DEFINITIONS = {
             "Health": 0.0
         }
     },
-    "Helios Infantry (FC8)": {
+    "Infantry (FC8)": {
         "Power": 110,
         "Defense": 23,
         "Lethality": 15,

--- a/tests/test_troop_definitions.py
+++ b/tests/test_troop_definitions.py
@@ -1,0 +1,17 @@
+import importlib
+import pathlib
+import sys
+
+# Add the server directory to the module search path
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT / 'server'))
+
+# ensure reload to pick up changes
+TROOP_DEFS = importlib.import_module('troop_data.troop_definitions').TROOP_DEFINITIONS
+
+def test_infantry_fc8_and_helios_present():
+    assert 'Infantry (FC8)' in TROOP_DEFS
+    assert 'Helios Infantry (FC8)' in TROOP_DEFS
+    base = TROOP_DEFS['Infantry (FC8)']['Power']
+    helios = TROOP_DEFS['Helios Infantry (FC8)']['Power']
+    assert helios > base


### PR DESCRIPTION
## Summary
- correct troop definitions by adding missing `Infantry (FC8)` entry
- test that both base and Helios FC8 infantry definitions exist

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689401bd08d88332b806467ac0dd4389