### PR TITLE
Apply hero and troop bonuses across expedition battles

### DIFF
--- a/BattleSimApp/components/ResultsSection.tsx
+++ b/BattleSimApp/components/ResultsSection.tsx
@@ -282,6 +282,7 @@ const SideBlock: React.FC<SBProps> = ({
               <Text style={[styles.tableHeaderCell, { flex: 2 }]}>Hero</Text>
               <Text style={[styles.tableHeaderCell, { flex: 1 }]}>Gen</Text>
               <Text style={[styles.tableHeaderCell, { flex: 1 }]}>Class</Text>
+              <Text style={[styles.tableHeaderCell, { flex: 1 }]}>EW Lv</Text>
               <Text style={[styles.tableHeaderCell, { flex: 1 }]}>Start</Text>
               <Text style={[styles.tableHeaderCell, { flex: 1 }]}>End</Text>
             </View>
@@ -290,6 +291,9 @@ const SideBlock: React.FC<SBProps> = ({
                 <Text style={[styles.tableCell, { flex: 2 }]}>{h.name}</Text>
                 <Text style={[styles.tableCell, { flex: 1 }]}>{h.generation}</Text>
                 <Text style={[styles.tableCell, { flex: 1 }]}>{cls}</Text>
+                <Text style={[styles.tableCell, { flex: 1 }]}>
+                  {h.exclusive_weapon?.level ?? "-"}
+                </Text>
                 <Text style={[styles.tableCell, { flex: 1 }]}>{SV(h.count_start)}</Text>
                 <Text style={[styles.tableCell, { flex: 1 }]}>{SV(h.count_end)}</Text>
               </View>

--- a/server/expedition_battle_mechanics/simulation.py
+++ b/server/expedition_battle_mechanics/simulation.py
@@ -61,6 +61,12 @@ def _hero_info(
             "class": hero.char_class,
             "generation": hero.generation,
             "skills": [s.name for s in hero.skills.get("expedition", [])],
+            "exclusive_weapon": {
+                "name": hero.exclusive_weapon.name,
+                "level": hero.exclusive_weapon.level,
+            }
+            if hero.exclusive_weapon
+            else None,
             "skill_pcts": skill_pcts,                 #  ← NEW
             "troop_level": grp.definition.name,
             "troop_power": grp.definition.power,

--- a/server/main.py
+++ b/server/main.py
@@ -94,8 +94,11 @@ def run_simulation(req: SimRequest):
     def_form = RallyFormation(def_heroes, req.defenderRatios, req.defenderCapacity, def_defs)
 
     # Bonus sources
-    atk_bonus = BonusSource(atk_heroes[0])
-    def_bonus = BonusSource(def_heroes[0])
+    # Aggregate permanent bonuses (city buffs, exclusive weapons, etc.) from
+    # **all** heroes on each side.  Previously only the first hero's exclusive
+    # weapon contributed, which skipped stats from the other two heroes.
+    atk_bonus = BonusSource(atk_heroes)
+    def_bonus = BonusSource(def_heroes)
 
     rpt = BattleReportInput(atk_form, def_form, atk_bonus, def_bonus)
 

--- a/tests/test_bonus_application.py
+++ b/tests/test_bonus_application.py
@@ -1,0 +1,121 @@
+import random
+
+import pathlib
+import sys
+
+import pytest
+
+# Add server directory to path so tests can import battle mechanics
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT / "server"))
+
+from expedition_battle_mechanics.bonus import BonusSource
+from expedition_battle_mechanics.combat_state import BattleReportInput
+from expedition_battle_mechanics.definitions import ExclusiveWeapon
+from expedition_battle_mechanics.formation import RallyFormation
+from expedition_battle_mechanics.hero import Hero
+from expedition_battle_mechanics.simulation import simulate_battle
+
+
+def _make_side(attack_bonus=0.0, defense_bonus=0.0, health_bonus=0.0):
+    heroes = [
+        Hero("I", "Infantry", "SSR", 1, {}, {"exploration": [], "expedition": []}),
+        Hero("L", "Lancer", "SSR", 1, {}, {"exploration": [], "expedition": []}),
+        Hero("M", "Marksman", "SSR", 1, {}, {"exploration": [], "expedition": []}),
+    ]
+    ratios = {"Infantry": 1.0, "Lancer": 0.0, "Marksman": 0.0}
+
+    td = {
+        "Infantry (FC1)": {
+            "Power": 100,
+            "Attack": 30,
+            "Defense": 10,
+            "Lethality": 0,
+            "Health": 10,
+            "StatBonuses": {
+                "Attack": 0.0,
+                "Defense": 0.0,
+                "Lethality": 0.0,
+                "Health": 0.0,
+            },
+        },
+        "Lancer (FC1)": {
+            "Power": 100,
+            "Attack": 30,
+            "Defense": 10,
+            "Lethality": 0,
+            "Health": 10,
+            "StatBonuses": {"Attack": 0.0, "Defense": 0.0, "Lethality": 0.0, "Health": 0.0},
+        },
+        "Marksman (FC1)": {
+            "Power": 100,
+            "Attack": 30,
+            "Defense": 10,
+            "Lethality": 0,
+            "Health": 10,
+            "StatBonuses": {"Attack": 0.0, "Defense": 0.0, "Lethality": 0.0, "Health": 0.0},
+        },
+    }
+
+    form = RallyFormation(heroes, ratios, 100, td)
+    bs = BonusSource(heroes, city_buffs={
+        "attack": attack_bonus,
+        "defense": defense_bonus,
+        "health": health_bonus,
+    })
+    return form, bs
+
+
+def _run(att_bonus=0.0, def_bonus=0.0, def_health=0.0):
+    atk_form, atk_bs = _make_side(attack_bonus=att_bonus)
+    def_form, def_bs = _make_side(defense_bonus=def_bonus, health_bonus=def_health)
+    rpt = BattleReportInput(atk_form, def_form, atk_bs, def_bs)
+    random.seed(0)
+    res = simulate_battle(rpt, max_rounds=1)
+    return res["defender"]["survivors"]["Infantry"]
+
+
+def test_attack_bonus_increases_damage():
+    base = _run()
+    buffed = _run(att_bonus=1.0)  # +100% attack
+    assert buffed < base
+
+
+def test_defense_bonus_reduces_damage():
+    base = _run()
+    tougher = _run(def_bonus=1.0)  # +100% defense
+    assert tougher > base
+
+
+def test_health_bonus_reduces_losses():
+    base = _run()
+    durable = _run(def_health=1.0)  # +100% health
+    assert durable > base
+
+
+def test_bonus_source_aggregates_exclusive_weapons():
+    h1 = Hero(
+        "H1",
+        "Infantry",
+        "SSR",
+        1,
+        {},
+        {"exploration": [], "expedition": []},
+        exclusive_weapon=ExclusiveWeapon(
+            name="W1", level=1, power=0, attack=0, defense=0, health=0, perks={"attack": 0.1}
+        ),
+    )
+    h2 = Hero(
+        "H2",
+        "Lancer",
+        "SSR",
+        1,
+        {},
+        {"exploration": [], "expedition": []},
+        exclusive_weapon=ExclusiveWeapon(
+            name="W2", level=1, power=0, attack=0, defense=0, health=0, perks={"attack": 0.2}
+        ),
+    )
+    bs = BonusSource([h1, h2])
+    assert bs.total_bonuses["attack"] == pytest.approx(0.3)
+


### PR DESCRIPTION
## Summary
- Aggregate exclusive-weapon perks and external buffs from all heroes using a revamped `BonusSource`
- Respect troop-class stat bonuses when computing damage and casualties in the expedition combat engine
- Surface exclusive weapon information and levels in battle reports and UI hero tables

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68940bc2e3f88332b208af9ae41d62b6