### PR TITLE
Handle simultaneous damage in expedition battles

### DIFF
--- a/tests/test_simultaneous_damage.py
+++ b/tests/test_simultaneous_damage.py
@@ -1,0 +1,62 @@
+import random
+import pathlib
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT / "server"))
+
+from expedition_battle_mechanics.formation import RallyFormation
+from expedition_battle_mechanics.hero import Hero
+from expedition_battle_mechanics.bonus import BonusSource
+from expedition_battle_mechanics.combat_state import BattleReportInput
+from expedition_battle_mechanics.simulation import simulate_battle
+
+
+def _make_side(capacity: int):
+    heroes = [
+        Hero("I", "Infantry", "SSR", 1, {}, {"exploration": [], "expedition": []}),
+        Hero("L", "Lancer", "SSR", 1, {}, {"exploration": [], "expedition": []}),
+        Hero("M", "Marksman", "SSR", 1, {}, {"exploration": [], "expedition": []}),
+    ]
+    ratios = {"Infantry": 0.0, "Lancer": 1.0, "Marksman": 0.0}
+    td = {
+        "Infantry (FC1)": {
+            "Power": 100,
+            "Attack": 30,
+            "Defense": 10,
+            "Lethality": 0,
+            "Health": 10,
+            "StatBonuses": {"Attack": 0.0, "Defense": 0.0, "Lethality": 0.0, "Health": 0.0},
+        },
+        "Lancer (FC1)": {
+            "Power": 100,
+            "Attack": 30,
+            "Defense": 10,
+            "Lethality": 0,
+            "Health": 10,
+            "StatBonuses": {"Attack": 0.0, "Defense": 0.0, "Lethality": 0.0, "Health": 0.0},
+        },
+        "Marksman (FC1)": {
+            "Power": 100,
+            "Attack": 30,
+            "Defense": 10,
+            "Lethality": 0,
+            "Health": 10,
+            "StatBonuses": {"Attack": 0.0, "Defense": 0.0, "Lethality": 0.0, "Health": 0.0},
+        },
+    }
+    form = RallyFormation(heroes, ratios, capacity, td)
+    bs = BonusSource(heroes)
+    return form, bs
+
+
+def test_defender_still_deals_damage_when_wiped():
+    atk_form, atk_bs = _make_side(100)
+    def_form, def_bs = _make_side(1)
+    rpt = BattleReportInput(atk_form, def_form, atk_bs, def_bs)
+
+    random.seed(0)
+    res = simulate_battle(rpt, max_rounds=1)
+
+    assert res["defender"]["survivors"]["Lancer"] == 0
+    assert res["attacker"]["survivors"]["Lancer"] < 100


### PR DESCRIPTION
## Summary
- Apply simultaneous damage resolution so defenders can retaliate before dying
- Add regression test for defender counterattacks even when wiped out

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689415ae81b48332aeece4a63e51b9d0