### PR TITLE
Apply troop skill bonuses correctly

### DIFF
--- a/server/expedition_battle_mechanics/combat_state.py
+++ b/server/expedition_battle_mechanics/combat_state.py
@@ -301,44 +301,42 @@ class CombatState:
         atk_mul = def_mul = 1.0
         dmg_mul = 1.0
 
+        # ---- Infantry ----
         if atk.class_name == "Infantry" and deff.class_name == "Lancer":
-            atk_mul *= 1.10
-            def_mul *= 1.10
+            atk_mul *= 1.10  # Master Brawler
 
         if deff.class_name == "Infantry":
-            def_mul *= 1.06
-            if random.random() < 0.375:
+            def_mul *= 1.06  # Body of Light (always-on portion)
+            if atk.class_name == "Lancer":
+                def_mul *= 1.10  # Bands of Steel
+            if random.random() < 0.375:  # Crystal Shield
                 dmg_mul = 0.0
                 self._proc("Crystal Shield", "def", deff.class_name.lower())
-                if random.random() < 0.15:
+                if random.random() < 0.15:  # Body of Light bonus when shield active
+                    dmg_mul *= 0.85
                     self._proc("Body of Light", "def", deff.class_name.lower())
 
-        if atk.class_name == "Infantry":
-            atk_mul *= 1.06
-            if random.random() < 0.375:
-                atk_mul *= 2.0
-                self._proc("Crystal Shield", "atk", atk.class_name.lower())
-                if random.random() < 0.15:
-                    self._proc("Body of Light", "atk", atk.class_name.lower())
-
+        # ---- Lancer ----
         if atk.class_name == "Lancer":
             if deff.class_name == "Marksman":
-                atk_mul *= 1.10
+                atk_mul *= 1.10  # Charge
             if random.random() < 0.15:
-                atk_mul *= 2.0
+                atk_mul *= 2.0  # Crystal Lance
                 self._proc("Crystal Lance", "atk", atk.class_name.lower())
         if deff.class_name == "Lancer" and random.random() < 0.10:
-            dmg_mul *= 0.5
+            dmg_mul *= 0.5  # Incandescent Field
             self._proc("Incandescent Field", "def", deff.class_name.lower())
 
+        # ---- Marksman ----
         if atk.class_name == "Marksman":
+            atk_mul *= 1.04  # Flame Charge base attack
             if deff.class_name == "Infantry":
-                atk_mul *= 1.10
+                atk_mul *= 1.10  # Ranged Strike
             if random.random() < 0.10:
-                atk_mul *= 2.0
+                atk_mul *= 2.0  # Volley
                 self._proc("Volley", "atk", atk.class_name.lower())
             if random.random() < 0.30:
-                atk_mul *= 1.50 * 1.25
+                atk_mul *= 1.50 * 1.25  # Crystal Gunpowder + Flame Charge bonus
                 self._proc("Crystal Gunpowder", "atk", atk.class_name.lower())
 
         return atk_mul, def_mul, dmg_mul

--- a/tests/test_troop_skills.py
+++ b/tests/test_troop_skills.py
@@ -1,0 +1,87 @@
+import pathlib
+import sys
+from unittest.mock import patch
+
+import pytest
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT / "server"))
+
+from expedition_battle_mechanics.combat_state import BattleReportInput, CombatState
+from expedition_battle_mechanics.formation import RallyFormation
+from expedition_battle_mechanics.hero import Hero
+from expedition_battle_mechanics.bonus import BonusSource
+
+
+def _make_state():
+    heroes = [
+        Hero("I", "Infantry", "SSR", 1, {}, {"exploration": [], "expedition": []}),
+        Hero("L", "Lancer", "SSR", 1, {}, {"exploration": [], "expedition": []}),
+        Hero("M", "Marksman", "SSR", 1, {}, {"exploration": [], "expedition": []}),
+    ]
+    ratios = {"Infantry": 1.0, "Lancer": 1.0, "Marksman": 1.0}
+    td = {
+        "Infantry (FC1)": {
+            "Power": 100,
+            "Attack": 30,
+            "Defense": 10,
+            "Lethality": 0,
+            "Health": 10,
+            "StatBonuses": {"Attack": 0.0, "Defense": 0.0, "Lethality": 0.0, "Health": 0.0},
+        },
+        "Lancer (FC1)": {
+            "Power": 100,
+            "Attack": 30,
+            "Defense": 10,
+            "Lethality": 0,
+            "Health": 10,
+            "StatBonuses": {"Attack": 0.0, "Defense": 0.0, "Lethality": 0.0, "Health": 0.0},
+        },
+        "Marksman (FC1)": {
+            "Power": 100,
+            "Attack": 30,
+            "Defense": 10,
+            "Lethality": 0,
+            "Health": 10,
+            "StatBonuses": {"Attack": 0.0, "Defense": 0.0, "Lethality": 0.0, "Health": 0.0},
+        },
+    }
+    atk_form = RallyFormation(heroes, ratios, 1, td)
+    def_form = RallyFormation(heroes, ratios, 1, td)
+    atk_bs = BonusSource(heroes)
+    def_bs = BonusSource(heroes)
+    rpt = BattleReportInput(atk_form, def_form, atk_bs, def_bs)
+    return CombatState(rpt)
+
+
+def test_infantry_vs_lancer_only_attack_bonus():
+    state = _make_state()
+    inf = state.attacker_groups["Infantry"]
+    lan = state.defender_groups["Lancer"]
+    with patch("random.random", return_value=1.0):
+        atk_mul, def_mul, dmg_mul = state._troop_skill_mods(inf, lan)
+    assert atk_mul == pytest.approx(1.10)
+    assert def_mul == pytest.approx(1.0)
+    assert dmg_mul == pytest.approx(1.0)
+
+
+def test_infantry_defense_against_lancer():
+    state = _make_state()
+    lan = state.attacker_groups["Lancer"]
+    inf = state.defender_groups["Infantry"]
+    with patch("random.random", return_value=1.0):
+        atk_mul, def_mul, dmg_mul = state._troop_skill_mods(lan, inf)
+    assert atk_mul == pytest.approx(1.0)
+    assert def_mul == pytest.approx(1.06 * 1.10)
+    assert dmg_mul == pytest.approx(1.0)
+
+
+def test_marksman_base_attack_bonus():
+    state = _make_state()
+    mar = state.attacker_groups["Marksman"]
+    lan = state.defender_groups["Lancer"]
+    with patch("random.random", return_value=1.0):
+        atk_mul, def_mul, dmg_mul = state._troop_skill_mods(mar, lan)
+    assert atk_mul == pytest.approx(1.04)
+    assert def_mul == pytest.approx(1.0)
+    assert dmg_mul == pytest.approx(1.0)


### PR DESCRIPTION
## Summary
- Correct troop skill logic so constant bonuses always apply while chance skills proc conditionally
- Add Flame Charge 4% base attack, proper Bands of Steel defense, and fix Infantry skill misuse
- Cover troop skill multipliers with unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68941af9dc6c833293f25f678eb3d157