### PR TITLE
Add temporary bonus system and Gordon skill handlers

### DIFF
--- a/server/expedition_battle_mechanics/skill_handlers/on_attack.py
+++ b/server/expedition_battle_mechanics/skill_handlers/on_attack.py
@@ -40,9 +40,28 @@ def bounty_temptation(state: Any, side: str, tg: TroopGroup, hero: Hero, lvl: in
     state.add_extra_damage(side, extra)
     state._proc("Bounty Temptation", side, tg.class_name)
 
+# ─────────────────────────────────────────────────────────────────────────────
+def venom_infusion(state: Any, side: str, tg: TroopGroup, hero: Hero, lvl: int) -> None:
+    if tg.class_name != "Lancer":
+        return
+    # Every 2 attacks → approximate with 50% chance
+    if random.random() >= 0.50:
+        return
+    pct = hero.skills_pct("Venom Infusion", lvl)
+    extra = hero.get_stat("attack") * pct * tg.count
+    state.add_extra_damage(side, extra)
+    # Enemy damage reduction for 1 turn
+    sk = next(s for s in hero.skills["expedition"] if s.name == "Venom Infusion")
+    dr_map = sk.extra.get("damage_reduction", {})
+    red = dr_map.get(str(lvl), 0.0)
+    enemy_side = "def" if side == "atk" else "atk"
+    state.add_temp_bonus(enemy_side, "attack", -red, 1)
+    state._proc("Venom Infusion", side, tg.class_name)
+
 # --------------------------------------------------------------------------- #
 ON_ATTACK: Dict[str, Handler] = {
     "King's Bestowal":  kings_bestowal,
     "Torrential Impact": torrential_impact,
     "Bounty Temptation": bounty_temptation,
+    "Venom Infusion":    venom_infusion,
 }

--- a/server/expedition_battle_mechanics/skill_handlers/on_turn.py
+++ b/server/expedition_battle_mechanics/skill_handlers/on_turn.py
@@ -29,8 +29,34 @@ def dragons_heir(state: Any, hero: Hero, lvl: int) -> None:
         state.add_extra_damage(hero.side, extra)
     state._proc("Dragon's Heir", hero.side)
 
+# --------------------------------------------------------------------------- #
+def chemical_terror(state: Any, hero: Hero, lvl: int) -> None:
+    if state.turn % 3:
+        return
+    pct = hero.skills_pct("Chemical Terror", lvl)
+    state.add_temp_bonus(hero.side, "Lancer-attack", pct, 1)
+    sk = next(s for s in hero.skills["expedition"] if s.name == "Chemical Terror")
+    enemy_red = sk.extra.get("enemy_damage_reduction", {}).get(str(lvl), 0.0)
+    enemy_side = "def" if hero.side == "atk" else "atk"
+    state.add_temp_bonus(enemy_side, "attack", -enemy_red, 1)
+    state._proc("Chemical Terror", hero.side)
+
+# --------------------------------------------------------------------------- #
+def toxic_release(state: Any, hero: Hero, lvl: int) -> None:
+    if state.turn % 4:
+        return
+    sk = next(s for s in hero.skills["expedition"] if s.name == "Toxic Release")
+    inf_inc = sk.extra.get("damage_taken_increase", {}).get(str(lvl), 0.0)
+    marks_red = sk.extra.get("marksmen_damage_reduction", {}).get(str(lvl), 0.0)
+    enemy_side = "def" if hero.side == "atk" else "atk"
+    state.add_temp_bonus(enemy_side, "Infantry-defense", -inf_inc, 2)
+    state.add_temp_bonus(enemy_side, "Marksman-attack", -marks_red, 2)
+    state._proc("Toxic Release", hero.side)
+
 # ─────────────────────────────────────────────────────────────────────────────
 ON_TURN: Dict[str, Handler] = {
     "Armor of Barnacles": armor_of_barnacles,
     "Dragon's Heir":      dragons_heir,
+    "Chemical Terror":    chemical_terror,
+    "Toxic Release":      toxic_release,
 }

--- a/tests/test_gordon_skill_handlers.py
+++ b/tests/test_gordon_skill_handlers.py
@@ -1,0 +1,72 @@
+import pathlib, sys
+from unittest.mock import patch
+
+import pytest
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT / "server"))
+
+import hero_data.hero_loader as hl
+from expedition_battle_mechanics.loader import hero_from_dict
+from expedition_battle_mechanics.troop import TroopGroup
+from expedition_battle_mechanics.definitions import TroopDefinition
+from expedition_battle_mechanics.skill_handlers.on_attack import venom_infusion
+from expedition_battle_mechanics.skill_handlers.on_turn import (
+    chemical_terror,
+    toxic_release,
+)
+
+
+class DummyState:
+    def __init__(self, turn=0):
+        self.turn = turn
+        self.extra = 0.0
+        self.temp_calls = []
+
+    def add_extra_damage(self, side, amount):
+        self.extra += amount
+
+    def add_temp_bonus(self, side, key, pct, turns):
+        self.temp_calls.append((side, key, pct, turns))
+
+    def _proc(self, *args, **kwargs):
+        pass
+
+
+def _lancer_group(count=10):
+    td = TroopDefinition(
+        name="Lancer (FC1)",
+        power=100,
+        attack=30,
+        defense=10,
+        lethality=0,
+        health=10,
+        stat_bonuses={},
+    )
+    return TroopGroup(td, count)
+
+
+def test_venom_infusion_extra_and_debuff():
+    gord = hero_from_dict(hl.HEROES["Gordon"])
+    gord.side = "atk"
+    tg = _lancer_group(10)
+    state = DummyState()
+    with patch("random.random", return_value=0.0):
+        venom_infusion(state, "atk", tg, gord, 5)
+    expected_extra = gord.get_stat("attack") * 1.0 * tg.count
+    assert state.extra == pytest.approx(expected_extra)
+    assert ("def", "attack", -0.20, 1) in state.temp_calls
+
+
+def test_chemical_terror_and_toxic_release_bonuses():
+    gord = hero_from_dict(hl.HEROES["Gordon"])
+    gord.side = "atk"
+    state = DummyState(turn=0)
+    chemical_terror(state, gord, 5)
+    assert ("atk", "Lancer-attack", 1.5, 1) in state.temp_calls
+    assert ("def", "attack", -0.30, 1) in state.temp_calls
+
+    state = DummyState(turn=0)
+    toxic_release(state, gord, 5)
+    assert ("def", "Infantry-defense", -0.30, 2) in state.temp_calls
+    assert ("def", "Marksman-attack", -0.30, 2) in state.temp_calls


### PR DESCRIPTION
## Summary
- track per-round stat bonuses in `CombatState` with helper for applying and decaying temporary effects
- implement expedition skill handlers for Gordon: Venom Infusion, Chemical Terror, Toxic Release
- add unit tests validating Gordon skill effects

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894e25e6620833297d85db7031c6bcd