### PR TITLE
Enhance battle report data output

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 fastapi==0.104.1
 uvicorn[standard]==0.24.0
 pydantic==2.5.0
+httpx<0.28


### PR DESCRIPTION
## Summary
- enrich hero battle reports with per-hero losses and kill rates
- add side-wide battle summaries with total kills, losses, and percentages
- include httpx dependency for tests

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894eb471bd8833283bfa88121e0027b