### PR TITLE
Implement special bonus mechanics

### DIFF
--- a/server/expedition_battle_mechanics/simulation.py
+++ b/server/expedition_battle_mechanics/simulation.py
@@ -171,6 +171,8 @@ def simulate_battle(
         "bonuses": {
             "attacker": state.attacker_bonus,
             "defender": state.defender_bonus,
+            "attacker_special": state.attacker_special,
+            "defender_special": state.defender_special,
         },
     }
 


### PR DESCRIPTION
## Summary
- separate regular and special combat bonuses so territory buffs use a non-stacking bucket
- apply special bonuses multiplicatively with an additional flat component for attack, defense and health
- expose special bonuses in battle reports and add tests covering the new formula

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894f31b96488332880524cc7861c284