### PR TITLE
Limit rally joiner contributions to first skill

### DIFF
--- a/server/expedition_battle_mechanics/formation.py
+++ b/server/expedition_battle_mechanics/formation.py
@@ -34,6 +34,29 @@ class RallyFormation:
         # rally joiners (may be empty)
         self.support_heroes: List[Hero] = list(support_heroes or [])
 
+        # Game rule: only the top four joiners contribute their first
+        # expedition skill and none of their exclusive‑weapon perks.  We sort
+        # joiners by the level of that first skill (highest first), truncate
+        # to four, then strip extra skills and equipment.
+
+        def _skill_level(hero: Hero) -> int:
+            if hero.skills.get("expedition"):
+                sk = hero.skills["expedition"][0]
+                return hero.selected_skill_levels.get(sk.name, 5)
+            return 0
+
+        # sort & truncate
+        self.support_heroes.sort(key=_skill_level, reverse=True)
+        self.support_heroes = self.support_heroes[:4]
+
+        # keep only the first expedition skill and remove exclusive weapons
+        for h in self.support_heroes:
+            if h.skills.get("expedition"):
+                h.skills["expedition"] = h.skills["expedition"][:1]
+            else:
+                h.skills["expedition"] = []
+            h.exclusive_weapon = None
+
         self.troop_ratios = troop_ratios  # e.g., {"Infantry": 0.5, "Lancer": 0.3, "Marksman": 0.2}
         self.total_capacity = total_capacity
         self.troop_definitions = troop_definitions

--- a/tests/test_support_hero_rules.py
+++ b/tests/test_support_hero_rules.py
@@ -1,0 +1,119 @@
+import pathlib
+import sys
+import pytest
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT / "server"))
+
+from expedition_battle_mechanics.bonus import BonusSource
+from expedition_battle_mechanics.combat_state import BattleReportInput
+from expedition_battle_mechanics.definitions import Skill, ExclusiveWeapon
+from expedition_battle_mechanics.formation import RallyFormation
+from expedition_battle_mechanics.hero import Hero
+from expedition_battle_mechanics.simulation import simulate_battle
+
+
+def _basic_troop_defs():
+    return {
+        "Infantry (FC1)": {
+            "Power": 100,
+            "Attack": 30,
+            "Defense": 10,
+            "Lethality": 0,
+            "Health": 10,
+            "StatBonuses": {"Attack": 0.0, "Defense": 0.0, "Lethality": 0.0, "Health": 0.0},
+        },
+        "Lancer (FC1)": {
+            "Power": 100,
+            "Attack": 30,
+            "Defense": 10,
+            "Lethality": 0,
+            "Health": 10,
+            "StatBonuses": {"Attack": 0.0, "Defense": 0.0, "Lethality": 0.0, "Health": 0.0},
+        },
+        "Marksman (FC1)": {
+            "Power": 100,
+            "Attack": 30,
+            "Defense": 10,
+            "Lethality": 0,
+            "Health": 10,
+            "StatBonuses": {"Attack": 0.0, "Defense": 0.0, "Lethality": 0.0, "Health": 0.0},
+        },
+    }
+
+
+def _base_heroes():
+    return [
+        Hero("I", "Infantry", "SSR", 1, {}, {"exploration": [], "expedition": []}),
+        Hero("L", "Lancer", "SSR", 1, {}, {"exploration": [], "expedition": []}),
+        Hero("M", "Marksman", "SSR", 1, {}, {"exploration": [], "expedition": []}),
+    ]
+
+
+def test_support_only_first_skill():
+    heroes = _base_heroes()
+    ratios = {"Infantry": 1.0, "Lancer": 0.0, "Marksman": 0.0}
+
+    sk1 = Skill(name="Abyssal Blessing", multiplier=0.10)
+    sk2 = Skill(name="Ironclad", multiplier=0.20)
+    support = Hero(
+        "Support",
+        "Marksman",
+        "SSR",
+        1,
+        {},
+        {"exploration": [], "expedition": [sk1, sk2]},
+    )
+
+    atk_form = RallyFormation(heroes, ratios, 100, _basic_troop_defs(), support_heroes=[support])
+    def_form = RallyFormation(heroes, ratios, 100, _basic_troop_defs())
+
+    atk_bs = BonusSource(atk_form.all_heroes())
+    def_bs = BonusSource(def_form.all_heroes())
+
+    rpt = BattleReportInput(atk_form, def_form, atk_bs, def_bs)
+    res = simulate_battle(rpt, max_rounds=1)
+
+    assert res["bonuses"]["attacker"].get("attack", 0.0) == pytest.approx(0.10)
+    assert "infantry_defense" not in res["bonuses"]["attacker"]
+
+
+def test_only_top_four_joiners():
+    heroes = _base_heroes()
+    ratios = {"Infantry": 1.0, "Lancer": 0.0, "Marksman": 0.0}
+
+    skill = Skill(name="Abyssal Blessing", multiplier=0.05)
+    supports = [
+        Hero(f"S{i}", "Marksman", "SSR", 1, {}, {"exploration": [], "expedition": [skill]})
+        for i in range(5)
+    ]
+
+    atk_form = RallyFormation(heroes, ratios, 100, _basic_troop_defs(), support_heroes=supports)
+    def_form = RallyFormation(heroes, ratios, 100, _basic_troop_defs())
+
+    atk_bs = BonusSource(atk_form.all_heroes())
+    def_bs = BonusSource(def_form.all_heroes())
+    rpt = BattleReportInput(atk_form, def_form, atk_bs, def_bs)
+    res = simulate_battle(rpt, max_rounds=1)
+
+    assert res["bonuses"]["attacker"].get("attack", 0.0) == pytest.approx(0.20)
+
+
+def test_support_exclusive_weapon_ignored():
+    heroes = _base_heroes()
+    ratios = {"Infantry": 1.0, "Lancer": 0.0, "Marksman": 0.0}
+
+    ew = ExclusiveWeapon(name="EW", level=1, power=0, attack=0, defense=0, health=0, perks={"attack": 0.15})
+    support = Hero(
+        "SupportEW",
+        "Marksman",
+        "SSR",
+        1,
+        {},
+        {"exploration": [], "expedition": []},
+        exclusive_weapon=ew,
+    )
+
+    atk_form = RallyFormation(heroes, ratios, 100, _basic_troop_defs(), support_heroes=[support])
+    bs = BonusSource(atk_form.all_heroes())
+    assert "attack" not in bs.base_bonuses


### PR DESCRIPTION
## Summary
- Restrict rally support heroes to top four joiners
- Ignore joiner exclusive weapons and extra skills
- Add tests covering support hero filtering rules

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6895361c2b008332aabdaf3435301082