### PR TITLE
Introduce strategy-based bonus stacking

### DIFF
--- a/server/expedition_battle_mechanics/skill_handlers/__init__.py
+++ b/server/expedition_battle_mechanics/skill_handlers/__init__.py
@@ -1,0 +1,44 @@
+"""Utilities shared across skill handler modules.
+
+This file currently exposes a small registry describing how passive skills
+should stack when multiple heroes provide the same buff.  The intention is to
+mirror in‑game rally rules where certain skills (e.g. flat damage boosts) can
+stack additively, while others such as chance‑based procs only apply their best
+instance.
+
+The registry can be expanded over time as more skills are analysed.  Unlisted
+skills default to additive stacking which matches the behaviour for most flat
+percentage bonuses discussed in the design brief.
+"""
+
+from __future__ import annotations
+
+from expedition_battle_mechanics.stacking import AdditiveStrategy, MaxStrategy, StackingStrategy
+
+
+# ---------------------------------------------------------------------------
+# Passive skill stacking configuration
+# ---------------------------------------------------------------------------
+# Mapping: skill name -> stacking strategy.  Only a small subset is modelled
+# here; additional entries can be added as new heroes or edge cases are
+# discovered.  Any skill missing from the mapping will simply stack additively.
+
+PASSIVE_STACKING: dict[str, StackingStrategy] = {
+    # Example of a non‑stacking passive: only the highest "Abyssal Blessing"
+    # across all participants should apply.  This mirrors guidance that most
+    # identical skills do not stack except for a few explicit exceptions like
+    # Jessie/Jasser.
+    "Abyssal Blessing": MaxStrategy(),
+
+    # Explicitly mark "Treasure Hunter" as additive to document a stacking
+    # exception where multiple copies are allowed.  This is useful for tests
+    # and serves as a template for future additive overrides.
+    "Treasure Hunter": AdditiveStrategy(),
+}
+
+
+def get_passive_strategy(name: str) -> StackingStrategy:
+    """Return the stacking strategy for ``name`` (defaults to additive)."""
+
+    return PASSIVE_STACKING.get(name, AdditiveStrategy())
+

--- a/server/expedition_battle_mechanics/stacking.py
+++ b/server/expedition_battle_mechanics/stacking.py
@@ -1,0 +1,70 @@
+"""Stacking strategies for combining battle bonuses.
+
+This module implements the **Strategy** design pattern so that different
+stacking rules (additive, multiplicative, highest-value wins, etc.) can be
+swapped in without altering calling code.  It keeps the battle engine
+extensible as new hero skills or buff types are introduced.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Dict
+
+
+class StackingStrategy(ABC):
+    """Combine ``current`` and ``value`` according to a stacking rule."""
+
+    @abstractmethod
+    def combine(self, current: float, value: float) -> float:  # pragma: no cover - interface
+        """Return the aggregated result for ``current`` and ``value``."""
+
+
+class AdditiveStrategy(StackingStrategy):
+    """Simple addition for stackable percentage bonuses."""
+
+    def combine(self, current: float, value: float) -> float:
+        return current + value
+
+
+class MaxStrategy(StackingStrategy):
+    """Keep the highest value encountered (non-stacking)."""
+
+    def combine(self, current: float, value: float) -> float:
+        return max(current, value)
+
+
+class MultiplicativeStrategy(StackingStrategy):
+    """Multiply percentages: ``(1+a) * (1+b) - 1``."""
+
+    def combine(self, current: float, value: float) -> float:
+        return (1 + current) * (1 + value) - 1
+
+
+class BonusBucket:
+    """Container that aggregates bonuses using a chosen strategy.
+
+    Exposes a lightweight dict-like API which keeps existing simulator code
+    largely unchanged while enabling more sophisticated stacking behaviour.
+    """
+
+    def __init__(self, strategy: StackingStrategy) -> None:
+        self.strategy = strategy
+        self._bonuses: Dict[str, float] = {}
+
+    def add(self, key: str, value: float) -> None:
+        self._bonuses[key] = self.strategy.combine(self._bonuses.get(key, 0.0), value)
+
+    # Dict-style helpers -------------------------------------------------
+    def as_dict(self) -> Dict[str, float]:
+        return self._bonuses
+
+    def get(self, key: str, default: float = 0.0) -> float:
+        return self._bonuses.get(key, default)
+
+    def items(self):  # pragma: no cover - simple passthrough
+        return self._bonuses.items()
+
+    def __getitem__(self, key: str) -> float:  # pragma: no cover
+        return self._bonuses[key]
+

--- a/tests/test_stacking_strategies.py
+++ b/tests/test_stacking_strategies.py
@@ -1,0 +1,35 @@
+import sys
+import pathlib
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT / "server"))
+
+import pytest
+from expedition_battle_mechanics.stacking import (
+    AdditiveStrategy,
+    BonusBucket,
+    MaxStrategy,
+    MultiplicativeStrategy,
+)
+
+
+def test_additive_strategy():
+    bucket = BonusBucket(AdditiveStrategy())
+    bucket.add("attack", 0.1)
+    bucket.add("attack", 0.2)
+    assert bucket.as_dict()["attack"] == pytest.approx(0.3)
+
+
+def test_max_strategy():
+    bucket = BonusBucket(MaxStrategy())
+    bucket.add("attack", 0.1)
+    bucket.add("attack", 0.25)
+    assert bucket.as_dict()["attack"] == pytest.approx(0.25)
+
+
+def test_multiplicative_strategy():
+    bucket = BonusBucket(MultiplicativeStrategy())
+    bucket.add("dmg", 0.1)
+    bucket.add("dmg", 0.2)
+    # (1+0.1)*(1+0.2)-1 = 0.32
+    assert bucket.as_dict()["dmg"] == pytest.approx(0.32)


### PR DESCRIPTION
## Summary
- add configuration for passive skill stacking strategies
- aggregate passive effects per skill so duplicates obey rally stacking rules
- test additive vs capped passive stacking and adjust joiner stacking tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68953a268fb08332836fa0a5039a4741