### PR TITLE
Add rally joiner support to frontend

### DIFF
--- a/BattleSimApp/App.tsx
+++ b/BattleSimApp/App.tsx
@@ -18,6 +18,7 @@ import {
 import { ConfigSection } from "./components/ConfigSection";
 import { ResultsSection } from "./components/ResultsSection";
 import { SideSetup } from "./components/SideSetup";
+import { JoinerRow } from "./components/JoinerRow";
 
 /* ─────────────── Main Component ─────────────── */
 export default function App() {
@@ -37,6 +38,9 @@ export default function App() {
   const [defH, setDefH] = useState<ClassSel>(emptySel);
   const [atkT, setAtkT] = useState<ClassSel>(emptySel);
   const [defT, setDefT] = useState<ClassSel>(emptySel);
+
+  const [atkSupport, setAtkSupport] = useState<string[]>(["", "", "", ""]);
+  const [defSupport, setDefSupport] = useState<string[]>(["", "", "", ""]);
 
   const [atkSlots, setAtkSlots] = useState<{ [cls in Class]: string }>({
     Infantry: "1",
@@ -107,6 +111,10 @@ export default function App() {
     sims: parseInt(sims, 10),
     attackerTroops: atkT,
     defenderTroops: defT,
+    attackerSupportHeroes:
+      attackType === "rally" ? atkSupport.filter((h) => h) : [],
+    defenderSupportHeroes:
+      attackType === "rally" ? defSupport.filter((h) => h) : [],
   });
 
   const runSim = () => {
@@ -168,6 +176,46 @@ export default function App() {
         setSlotSel={setDefSlots}
         setRatioSel={setDefRatios}
       />
+
+      {attackType === "rally" && (
+        <>
+          <Text style={styles.subHeader}>Attacker Joiners</Text>
+          {atkSupport.map((sel, idx) => (
+            <JoinerRow
+              key={`atk-joiner-${idx}`}
+              side="atk"
+              idx={idx}
+              heroes={heroes}
+              selected={sel}
+              onChange={(v) =>
+                setAtkSupport((s) => {
+                  const arr = [...s];
+                  arr[idx] = v;
+                  return arr;
+                })
+              }
+            />
+          ))}
+
+          <Text style={styles.subHeader}>Defender Joiners</Text>
+          {defSupport.map((sel, idx) => (
+            <JoinerRow
+              key={`def-joiner-${idx}`}
+              side="def"
+              idx={idx}
+              heroes={heroes}
+              selected={sel}
+              onChange={(v) =>
+                setDefSupport((s) => {
+                  const arr = [...s];
+                  arr[idx] = v;
+                  return arr;
+                })
+              }
+            />
+          ))}
+        </>
+      )}
 
       {/* config + run */}
       <ConfigSection

--- a/BattleSimApp/components/JoinerRow.tsx
+++ b/BattleSimApp/components/JoinerRow.tsx
@@ -1,0 +1,70 @@
+import React from "react";
+import { Picker } from "@react-native-picker/picker";
+import { Text, View } from "react-native";
+import { Hero } from "../types";
+import { styles } from "../styles";
+
+interface Props {
+  side: "atk" | "def";
+  idx: number;
+  heroes: Hero[];
+  selected: string;
+  onChange: (name: string) => void;
+}
+
+export const JoinerRow: React.FC<Props> = ({ side, idx, heroes, selected, onChange }) => {
+  const heroItems = (() => {
+    const list = heroes.sort((a, b) =>
+      a.generation === b.generation
+        ? a.name.localeCompare(b.name)
+        : a.generation - b.generation
+    );
+    let lastGen: number | null = null;
+    return list.flatMap((h) => {
+      const arr: React.ReactElement[] = [];
+      if (h.generation !== lastGen) {
+        arr.push(
+          <Picker.Item
+            key={`hdr-${side}-joiner-${idx}-${h.generation}`}
+            label={`-- Gen ${h.generation} --`}
+            value=""
+            enabled={false}
+            color="#FFFFFF"
+          />
+        );
+        lastGen = h.generation;
+      }
+      arr.push(
+        <Picker.Item
+          key={`${side}-joiner-${idx}-${h.name}`}
+          label={h.name}
+          value={h.name}
+          color="#FFFFFF"
+        />
+      );
+      return arr;
+    });
+  })();
+
+  const col = side === "atk" ? styles.attackerLabel : styles.defenderLabel;
+  const pickStyle = side === "atk" ? styles.attackerPicker : styles.defenderPicker;
+
+  return (
+    <View style={styles.row}>
+      <Text style={[styles.label, col]}>
+        Joiner {idx + 1} Hero {side === "atk" ? "(Attacker)" : "(Defender)"}
+      </Text>
+      <Picker
+        selectedValue={selected}
+        onValueChange={onChange}
+        style={[styles.picker, pickStyle]}
+        dropdownIconColor="#FFFFFF"
+        itemStyle={{ color: "#FFFFFF" }}
+      >
+        <Picker.Item label="None" value="" color="#FFFFFF" />
+        {heroItems}
+      </Picker>
+    </View>
+  );
+};
+


### PR DESCRIPTION
## Summary
- add joiner selection component
- display four joiner pickers when attack type is Rally
- send selected joiner heroes to backend

## Testing
- `npm test --prefix BattleSimApp` *(fails: Missing script: "test")*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68954bf375d88332a5321b288946d950