### PR TITLE
Improve Swap Lab efficiency and swap accuracy

### DIFF
--- a/src/features/battle-calculator/tabs/swap-lab/SwapLabTab.tsx
+++ b/src/features/battle-calculator/tabs/swap-lab/SwapLabTab.tsx
@@ -66,127 +66,134 @@ export default function SwapLabTab({
     if (!currentProfile?.rally) return;
 
     setRunning(true);
-
-    const mix = {
-      ...(currentProfile.rally.troopMix?.player ?? { infantryRatio: 33.34, lancerRatio: 33.33, marksmanRatio: 33.33 }),
-      totalTroops: capacityTotal
-    };
-
-    // Only run the selected slot unless "All slots" is chosen.
-    const slotsToRun: SwapSlot[] = selectedSlot === 'all' ? SLOTS : [selectedSlot];
-
-    const slotCandidatePairs: { slot: SwapSlot; candidate: string }[] = [];
-    for (const slot of slotsToRun) {
-      const candidates = getCandidatesForSlot(slot).slice(0, MAX_CANDIDATES_PER_SLOT);
-      for (const candidate of candidates) {
-        slotCandidatePairs.push({ slot, candidate });
-      }
-    }
-
-    const totalSwaps = slotCandidatePairs.length;
-
-    // ——— Phase 1: Fast screening ———
-    setProgress({ completed: 0, total: totalSwaps + 1, phase: 'screening' });
-
-    const baselineInput: ScenarioRunInput = {
-      profile: currentProfile,
-      playerBaseStats,
-      opponentBaseStats,
-      playerCapacityReport,
-      opponentCapacityReport,
-      playerMixOverride: {
-        ...(currentProfile.rally?.troopMix?.player ?? { infantryRatio: 33.34, lancerRatio: 33.33, marksmanRatio: 33.33 }),
+    try {
+      const mix = {
+        ...(currentProfile.rally.troopMix?.player ?? { infantryRatio: 33.34, lancerRatio: 33.33, marksmanRatio: 33.33 }),
         totalTroops: capacityTotal
+      };
+
+      // Only run the selected slot unless "All slots" is chosen.
+      const slotsToRun: SwapSlot[] = selectedSlot === 'all' ? SLOTS : [selectedSlot];
+
+      const slotCandidatePairs: { slot: SwapSlot; candidate: string }[] = [];
+      for (const slot of slotsToRun) {
+        const candidates = getCandidatesForSlot(slot, currentProfile).slice(0, MAX_CANDIDATES_PER_SLOT);
+        for (const candidate of candidates) {
+          slotCandidatePairs.push({ slot, candidate });
+        }
       }
-    };
 
-    const baselinePhase1 = runSingleScenario(baselineInput);
-    setBaselineResult(baselinePhase1);
-    const baselineWinRatePhase1 = toWinRate(baselinePhase1);
+      const totalSwaps = slotCandidatePairs.length;
+      if (totalSwaps === 0) {
+        setRows([]);
+        setProgress({ completed: 0, total: 0, phase: 'screening' });
+        return;
+      }
 
-    const results: SwapRow[] = [];
+      // ——— Phase 1: Fast screening ———
+      setProgress({ completed: 0, total: totalSwaps + 1, phase: 'screening' });
 
-    for (let i = 0; i < slotCandidatePairs.length; i++) {
-      const { slot, candidate } = slotCandidatePairs[i];
-
-      const modifiedProfile = profileWithSlotOverride(currentProfile, slot, candidate);
-
-      const input: ScenarioRunInput = {
-        profile: modifiedProfile,
+      const baselineInput: ScenarioRunInput = {
+        profile: currentProfile,
         playerBaseStats,
         opponentBaseStats,
         playerCapacityReport,
         opponentCapacityReport,
-        playerMixOverride: mix
+        playerMixOverride: {
+          ...(currentProfile.rally?.troopMix?.player ?? { infantryRatio: 33.34, lancerRatio: 33.33, marksmanRatio: 33.33 }),
+          totalTroops: capacityTotal
+        }
       };
 
-      const result = runSingleScenario(input);
-      const swapWinRatePhase1 = toWinRate(result);
+      const baselinePhase1 = runSingleScenario(baselineInput);
+      setBaselineResult(baselinePhase1);
+      const baselineWinRatePhase1 = toWinRate(baselinePhase1);
 
-      results.push({
-        slot,
-        candidate,
-        deltaWinRate: (swapWinRatePhase1 - baselineWinRatePhase1) * 100,
-        baselineWinRate: baselineWinRatePhase1,
-        swapWinRate: swapWinRatePhase1,
-        baselineWinner: baselinePhase1.summary.winner,
-        swapWinner: result.summary.winner
-      });
+      const results: SwapRow[] = [];
 
-      // Don't spam React state; update UI every few iterations.
-      if ((i + 1) % 4 === 0 || i === slotCandidatePairs.length - 1) {
-        setProgress({ completed: i + 1, total: totalSwaps + 1, phase: 'screening' });
-        setRows([...results]);
+      for (let i = 0; i < slotCandidatePairs.length; i++) {
+        const { slot, candidate } = slotCandidatePairs[i];
+
+        const modifiedProfile = profileWithSlotOverride(currentProfile, slot, candidate);
+
+        const input: ScenarioRunInput = {
+          profile: modifiedProfile,
+          playerBaseStats,
+          opponentBaseStats,
+          playerCapacityReport,
+          opponentCapacityReport,
+          playerMixOverride: mix
+        };
+
+        const result = runSingleScenario(input);
+        const swapWinRatePhase1 = toWinRate(result);
+
+        results.push({
+          slot,
+          candidate,
+          deltaWinRate: (swapWinRatePhase1 - baselineWinRatePhase1) * 100,
+          baselineWinRate: baselineWinRatePhase1,
+          swapWinRate: swapWinRatePhase1,
+          baselineWinner: baselinePhase1.summary.winner,
+          swapWinner: result.summary.winner
+        });
+
+        // Don't spam React state; update UI every few iterations.
+        if ((i + 1) % 4 === 0 || i === slotCandidatePairs.length - 1) {
+          setProgress({ completed: i + 1, total: totalSwaps + 1, phase: 'screening' });
+          setRows([...results]);
+          await new Promise((r) => setTimeout(r, 0));
+        }
+      }
+
+      results.sort((a, b) => b.deltaWinRate - a.deltaWinRate);
+      setRows(results);
+      await new Promise((r) => setTimeout(r, 0));
+
+      // ——— Phase 2: Monte Carlo refinement for top N only ———
+      const toRefine = results.slice(0, TOP_N_TO_REFINE);
+      setProgress({ completed: 0, total: toRefine.length + 1, phase: 'refining' });
+
+      const baselineRefined = await runSingleScenarioWithTrials(baselineInput, TRIALS_REFINE);
+      setBaselineResult(baselineRefined);
+      const baselineWinRate = toWinRate(baselineRefined);
+
+      for (let i = 0; i < toRefine.length; i++) {
+        const row = toRefine[i];
+
+        const modifiedProfile = profileWithSlotOverride(currentProfile, row.slot, row.candidate);
+
+        const input: ScenarioRunInput = {
+          profile: modifiedProfile,
+          playerBaseStats,
+          opponentBaseStats,
+          playerCapacityReport,
+          opponentCapacityReport,
+          playerMixOverride: mix
+        };
+
+        const result = await runSingleScenarioWithTrials(input, TRIALS_REFINE);
+        const swapWinRate = toWinRate(result);
+
+        const idx = results.findIndex((r) => r.slot === row.slot && r.candidate === row.candidate);
+        if (idx !== -1) {
+          results[idx] = {
+            ...results[idx],
+            refinedWinRate: swapWinRate,
+            refinedDelta: (swapWinRate - baselineWinRate) * 100,
+            swapWinner: result.summary.winner
+          };
+        }
+
+        setProgress({ completed: i + 1, total: toRefine.length + 1, phase: 'refining' });
+        setRows([...results].sort((a, b) => (b.refinedDelta ?? b.deltaWinRate) - (a.refinedDelta ?? a.deltaWinRate)));
         await new Promise((r) => setTimeout(r, 0));
       }
-    }
 
-    results.sort((a, b) => b.deltaWinRate - a.deltaWinRate);
-    setRows(results);
-    await new Promise((r) => setTimeout(r, 0));
-
-    // ——— Phase 2: Monte Carlo refinement for top N only ———
-    const toRefine = results.slice(0, TOP_N_TO_REFINE);
-    setProgress({ completed: 0, total: toRefine.length + 1, phase: 'refining' });
-
-    const baselineRefined = await runSingleScenarioWithTrials(baselineInput, TRIALS_REFINE);
-    setBaselineResult(baselineRefined);
-    const baselineWinRate = toWinRate(baselineRefined);
-
-    for (let i = 0; i < toRefine.length; i++) {
-      const row = toRefine[i];
-
-      const modifiedProfile = profileWithSlotOverride(currentProfile, row.slot, row.candidate);
-
-      const input: ScenarioRunInput = {
-        profile: modifiedProfile,
-        playerBaseStats,
-        opponentBaseStats,
-        playerCapacityReport,
-        opponentCapacityReport,
-        playerMixOverride: mix
-      };
-
-      const result = await runSingleScenarioWithTrials(input, TRIALS_REFINE);
-      const swapWinRate = toWinRate(result);
-
-      const idx = results.findIndex((r) => r.slot === row.slot && r.candidate === row.candidate);
-      if (idx !== -1) {
-        results[idx] = {
-          ...results[idx],
-          refinedWinRate: swapWinRate,
-          refinedDelta: (swapWinRate - baselineWinRate) * 100,
-          swapWinner: result.summary.winner
-        };
-      }
-
-      setProgress({ completed: i + 1, total: toRefine.length + 1, phase: 'refining' });
       setRows([...results].sort((a, b) => (b.refinedDelta ?? b.deltaWinRate) - (a.refinedDelta ?? a.deltaWinRate)));
-      await new Promise((r) => setTimeout(r, 0));
+    } finally {
+      setRunning(false);
     }
-
-    setRows([...results].sort((a, b) => (b.refinedDelta ?? b.deltaWinRate) - (a.refinedDelta ?? a.deltaWinRate)));
-    setRunning(false);
   }, [currentProfile, playerBaseStats, opponentBaseStats, playerCapacityReport, opponentCapacityReport, capacityTotal, selectedSlot]);
 
   return (

--- a/src/features/battle-calculator/tabs/swap-lab/__tests__/swapLabUtils.test.ts
+++ b/src/features/battle-calculator/tabs/swap-lab/__tests__/swapLabUtils.test.ts
@@ -1,0 +1,60 @@
+import { HEROES_BY_CLASS } from '@/domain/battle/data/heroes/heroes';
+import type { UserProfile } from '@/shared/types';
+import { describe, expect, it } from 'vitest';
+import { getCandidatesForSlot, profileWithSlotOverride } from '../swapLabUtils';
+
+function makeProfile(): UserProfile {
+  const infantryHero = HEROES_BY_CLASS.infantry[0]['hero-name'];
+  const infantryHero2 = HEROES_BY_CLASS.infantry[1]['hero-name'];
+  const lancerHero = HEROES_BY_CLASS.lancer[0]['hero-name'];
+  const lancerHero2 = HEROES_BY_CLASS.lancer[1]['hero-name'];
+  const marksmanHero = HEROES_BY_CLASS.marksman[0]['hero-name'];
+
+  return {
+    id: 'p1',
+    name: 'Test',
+    rally: {
+      leader: {
+        infantry: { heroName: infantryHero, heroClass: 'infantry', starLevel: 1, generation: 1, skillLevels: {}, xpLevel: 80 },
+        lancer: { heroName: lancerHero, heroClass: 'lancer', starLevel: 1, generation: 1, skillLevels: {}, xpLevel: 80 },
+        marksman: { heroName: marksmanHero, heroClass: 'marksman', starLevel: 1, generation: 1, skillLevels: {}, xpLevel: 80 }
+      },
+      playerLeader: {
+        infantry: { heroName: infantryHero, heroClass: 'infantry', starLevel: 1, generation: 1, skillLevels: {}, xpLevel: 80 },
+        lancer: { heroName: lancerHero, heroClass: 'lancer', starLevel: 1, generation: 1, skillLevels: {}, xpLevel: 80 },
+        marksman: { heroName: marksmanHero, heroClass: 'marksman', starLevel: 1, generation: 1, skillLevels: {}, xpLevel: 80 }
+      },
+      playerJoiners: [
+        { heroName: infantryHero2, heroClass: 'infantry', starLevel: 1, generation: 1, skillLevels: {}, xpLevel: 80 },
+        { heroName: lancerHero2, heroClass: 'lancer', starLevel: 1, generation: 1, skillLevels: {}, xpLevel: 80 }
+      ],
+      opponentLeader: { infantry: null, lancer: null, marksman: null },
+      opponentJoiners: [],
+      capacity: { infantry: [], lancer: [], marksman: [] },
+      troopMix: {
+        player: { totalTroops: 1000, infantryRatio: 33.34, lancerRatio: 33.33, marksmanRatio: 33.33 },
+        opponent: { totalTroops: 1000, infantryRatio: 33.34, lancerRatio: 33.33, marksmanRatio: 33.33 }
+      }
+    }
+  } as unknown as UserProfile;
+}
+
+describe('swapLabUtils', () => {
+  it('filters out occupied heroes and no-op same-slot candidates', () => {
+    const profile = makeProfile();
+    const candidates = getCandidatesForSlot('infantry_leader', profile);
+    const currentInfantry = profile.rally?.playerLeader?.infantry?.heroName as string;
+    const occupiedJoiner = profile.rally?.playerJoiners?.[0]?.heroName as string;
+
+    expect(candidates).not.toContain(currentInfantry);
+    expect(candidates).not.toContain(occupiedJoiner);
+  });
+
+  it('does not allow duplicate hero assignment across rally slots', () => {
+    const profile = makeProfile();
+    const existingLancerLeader = profile.rally?.playerLeader?.lancer?.heroName as string;
+
+    const updated = profileWithSlotOverride(profile, 'joiner_3', existingLancerLeader);
+    expect(updated).toBe(profile);
+  });
+});

--- a/src/features/battle-calculator/tabs/swap-lab/swapLabUtils.ts
+++ b/src/features/battle-calculator/tabs/swap-lab/swapLabUtils.ts
@@ -40,13 +40,54 @@ export function getSlotLabel(slot: SwapSlot): string {
   return SLOT_LABELS[slot];
 }
 
-/** Hero names that are valid for this slot (leader slots = same class only; joiners = all). */
-export function getCandidatesForSlot(slot: SwapSlot): string[] {
-  const requiredClass = SLOT_CLASS[slot];
-  if (requiredClass == null) {
-    return HEROES.map((h) => h['hero-name']);
+function getHeroNameInSlot(profile: UserProfile, slot: SwapSlot): string | null {
+  const rally = profile.rally;
+  if (!rally) return null;
+
+  const leaders = rally.playerLeader ?? rally.leader;
+  const joiners = rally.playerJoiners ?? rally.joiners ?? [];
+
+  if (slot === 'infantry_leader') return leaders?.infantry?.heroName ?? null;
+  if (slot === 'lancer_leader') return leaders?.lancer?.heroName ?? null;
+  if (slot === 'marksman_leader') return leaders?.marksman?.heroName ?? null;
+
+  const idx = slot === 'joiner_0' ? 0 : slot === 'joiner_1' ? 1 : slot === 'joiner_2' ? 2 : 3;
+  return joiners[idx]?.heroName ?? null;
+}
+
+function getOccupiedHeroNames(profile: UserProfile): Set<string> {
+  const occupied = new Set<string>();
+  const rally = profile.rally;
+  if (!rally) return occupied;
+
+  const leaders = rally.playerLeader ?? rally.leader;
+  const joiners = rally.playerJoiners ?? rally.joiners ?? [];
+
+  if (leaders?.infantry?.heroName) occupied.add(leaders.infantry.heroName);
+  if (leaders?.lancer?.heroName) occupied.add(leaders.lancer.heroName);
+  if (leaders?.marksman?.heroName) occupied.add(leaders.marksman.heroName);
+  for (const joiner of joiners.slice(0, 4)) {
+    if (joiner?.heroName) occupied.add(joiner.heroName);
   }
-  return HEROES_BY_CLASS[requiredClass].map((h) => h['hero-name']);
+
+  return occupied;
+}
+
+/** Hero names that are valid for this slot (leader slots = same class only; joiners = all). */
+export function getCandidatesForSlot(slot: SwapSlot, profile?: UserProfile): string[] {
+  const requiredClass = SLOT_CLASS[slot];
+  const candidates = requiredClass == null
+    ? HEROES.map((h) => h['hero-name'])
+    : HEROES_BY_CLASS[requiredClass].map((h) => h['hero-name']);
+
+  if (!profile?.rally) return candidates;
+
+  const occupied = getOccupiedHeroNames(profile);
+  const heroInCurrentSlot = getHeroNameInSlot(profile, slot);
+  if (heroInCurrentSlot) occupied.delete(heroInCurrentSlot);
+
+  // Exclude no-op swaps (same hero already in slot) and impossible duplicate lineups.
+  return candidates.filter((name) => name !== heroInCurrentSlot && !occupied.has(name));
 }
 
 const DEFAULT_HERO_LEVELS = {
@@ -100,6 +141,14 @@ export function profileWithSlotOverride(
   const heroClass = hero['hero-class'] as 'infantry' | 'lancer' | 'marksman';
   const requiredClass = SLOT_CLASS[slot];
   if (requiredClass != null && heroClass !== requiredClass) {
+    return profile;
+  }
+
+  const occupied = getOccupiedHeroNames(profile);
+  const heroInCurrentSlot = getHeroNameInSlot(profile, slot);
+  if (heroInCurrentSlot) occupied.delete(heroInCurrentSlot);
+  if (occupied.has(heroName)) {
+    // Keep lineups valid: the same hero cannot occupy two different player rally slots.
     return profile;
   }
 


### PR DESCRIPTION
### Motivation
- The Swap Lab was evaluating invalid or no-op swaps which wasted CPU and produced misleading rankings.
- Overwrites could accidentally create duplicate hero assignments across rally slots leading to impossible/invalid lineups. 
- The UI did not always clear `running` on error or early exit, risking stuck loading state for long runs.

### Description
- Add profile-aware candidate filtering by extending `getCandidatesForSlot` to accept `profile` and exclude the hero already in the target slot and any heroes already used in other player rally slots (new helpers `getHeroNameInSlot` and `getOccupiedHeroNames`). (modified `swapLabUtils.ts`)
- Harden `profileWithSlotOverride` to reject attempts that would assign a hero already present in another player rally slot, preventing duplicate occupancy. (modified `swapLabUtils.ts`)
- Use the profile-aware candidate list inside the runner by calling `getCandidatesForSlot(slot, currentProfile)` and limit candidates to `MAX_CANDIDATES_PER_SLOT`. (modified `SwapLabTab.tsx`)
- Wrap the main `runSwaps` flow in a `try/finally` so `setRunning(false)` always executes, and early-exit when no valid candidates are found to avoid wasted work. (modified `SwapLabTab.tsx`)
- Add focused unit tests that assert occupied heroes are filtered from candidates and that `profileWithSlotOverride` blocks duplicate assignments. (new test file `__tests__/swapLabUtils.test.ts`)

### Testing
- Ran the new unit tests with `npm run test -- src/features/battle-calculator/tabs/swap-lab/__tests__/swapLabUtils.test.ts` and they passed (`2 passed`).
- Ran lint on the modified files with `npm run lint -- src/features/battle-calculator/tabs/swap-lab/SwapLabTab.tsx src/features/battle-calculator/tabs/swap-lab/swapLabUtils.ts` and the lint process completed without errors for the checked files.
- All changes were committed and included the new test file (`src/features/battle-calculator/tabs/swap-lab/__tests__/swapLabUtils.test.ts`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699931a8fe94833291547a59dfa71e0f)